### PR TITLE
Fixed Multiplicand Width

### DIFF
--- a/vlsiffra/multiplier.py
+++ b/vlsiffra/multiplier.py
@@ -172,7 +172,7 @@ class BoothRadix4(Elaboratable):
         # Add a zero in the LSB of the multiplier and multiplicand
         self.m.d.comb += [
             multiplier.eq(Cat(Const(0), self.a_registered, Const(0), Const(0))),
-            multiplicand.eq(Cat(Const(0), self.b_registered)),
+            multiplicand.eq(Cat(Const(0), self.b_registered, Const(0))),
         ]
 
         last_b = self._bits


### PR DESCRIPTION
Early pull request was an untested mistake. Made the verilog clean, but broke the multiplier.