### PR TITLE
Use Amaranth from git for newer Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  python:
+  pythontests:
     timeout-minutes: 10
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        container:
+          - ubuntu:20.04
+          - ubuntu:22.04
+          - ubuntu:22.10
+          - ubuntu:23.04
+          - debian:unstable
+      fail-fast: false
 
+    runs-on: ubuntu-22.04
+    container: ${{ matrix.container }}
     steps:
+      - name: Install basic deps
+        run: |
+          apt-get update -y
+          apt-get install -y \
+            git \
+            make \
+            python3 \
+            python3-pip \
+            python3-venv \
+
       - uses: actions/checkout@v2
 
       - name: Run python tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 0 * * 5'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   python:
     timeout-minutes: 10

--- a/ci/create_venv.sh
+++ b/ci/create_venv.sh
@@ -2,6 +2,7 @@
 
 python3 -m venv venv
 source venv/bin/activate
+python3 -c 'import sys; print("Python version:", sys.version)'
 pip3 install .
 pip3 install unittest-parallel
 pip3 install flake8

--- a/ci/create_venv.sh
+++ b/ci/create_venv.sh
@@ -3,6 +3,13 @@
 python3 -m venv venv
 source venv/bin/activate
 python3 -c 'import sys; print("Python version:", sys.version)'
+
+# Until amaranth 0.4 is published, Pythons newer than 3.9 need to install from git.
+if [ "$(python3 -c 'import sys; print(sys.version_info[1])')" -gt 9 ]; then
+	echo "Using Amaranth from GitHub as Python >3.9 (remove after Amaranth 0.4 is released)."
+	pip3 install "git+https://github.com/amaranth-lang/amaranth.git#egg=amaranth"
+fi
+
 pip3 install .
 pip3 install unittest-parallel
 pip3 install flake8


### PR DESCRIPTION
Fixes #26.

Currently Amaranth is broken for newer Python versions. Until a new version is published, this hack installs Amaranth directly from Git.